### PR TITLE
Add "Management" to "Scrum/Agile" topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ _Docker_
   
 **[`^        back to top        ^`](#)**
    
-## Scrum/Agile
+## Scrum/Agile/Management
 
 - [Udacity: Become a Product Manager](https://www.udacity.com/course/product-manager-nanodegree--nd036)
 - [Different Scrum Roles Training For Certification](https://www.scrum.org)


### PR DESCRIPTION
Some of our colleagues want to learn more about management or project management. The "Scrum / Agile" topic already covers certain versions of management and, I believe, it is a good place to also include other versions of "traditional" management, like Waterfall, Prince 2, PMP, etc.

If traditional management becomes a big thing on its own we can split it out into a separate topic.